### PR TITLE
enable choosing if text should be imported as vectors or text

### DIFF
--- a/scribus/plugins/import/pdf/importpdf.cpp
+++ b/scribus/plugins/import/pdf/importpdf.cpp
@@ -430,6 +430,7 @@ bool PdfPlug::convert(const QString& fn)
 				else if (getCBox(Art_Box, 1) != mediaRect)
 					boxesAreDifferent = true;
 				bool cropped = false;
+				bool importTextAsVectors = true;
 				int contentRect = Media_Box;
 				if (((interactive) || (importerFlags & LoadSavePlugin::lfCreateDoc)) && ((lastPage > 1) || boxesAreDifferent))
 				{
@@ -455,6 +456,7 @@ bool PdfPlug::convert(const QString& fn)
 					cropped = optImp->croppingEnabled();
 					if (!cropped)
 						crop = cropped;
+					importTextAsVectors = optImp->getImportAsVectors();
 					// When displaying  pages slices, we should always set useMediaBox to true
 					// in order to use MediaBox (x, y) as coordinate system
 					if (contentRect != Media_Box)
@@ -471,6 +473,7 @@ bool PdfPlug::convert(const QString& fn)
 				SlaOutputDev *dev = new SlaOutputDev(m_Doc, &Elements, &importedColors, importerFlags);
 				if (dev->isOk())
 				{
+					dev->importTextAsVectors = importTextAsVectors;
 					OCGs* ocg = pdfDoc->getOptContentConfig();
 					if (ocg)
 					{

--- a/scribus/plugins/import/pdf/pdfimportoptions.cpp
+++ b/scribus/plugins/import/pdf/pdfimportoptions.cpp
@@ -61,6 +61,11 @@ bool PdfImportOptions::croppingEnabled()
 	return ui->cropGroup->isChecked();
 }
 
+bool PdfImportOptions::getImportAsVectors()
+{
+	return ui->textAsVectors->isChecked();
+}
+
 void PdfImportOptions::setUpOptions(const QString& fileName, int actPage, int numPages, bool interact, bool cropPossible, PdfPlug* plug)
 {
 	m_plugin = plug;
@@ -71,6 +76,8 @@ void PdfImportOptions::setUpOptions(const QString& fileName, int actPage, int nu
 	ui->cropGroup->setVisible(cropPossible);
 	ui->cropGroup->setChecked(cropPossible);
 	ui->cropBox->setCurrentIndex(3); // Use CropBox by default
+	ui->textAsVectors->setChecked(true);
+	ui->textAsText->setChecked(false);
 	if (interact)
 	{
 		ui->allPages->setChecked(false);

--- a/scribus/plugins/import/pdf/pdfimportoptions.h
+++ b/scribus/plugins/import/pdf/pdfimportoptions.h
@@ -25,6 +25,7 @@ public:
 	QString getPagesString();
 	int getCropBox();
 	bool croppingEnabled();
+	bool getImportAsVectors();
 	void paintEvent(QPaintEvent *e);
 
 protected:

--- a/scribus/plugins/import/pdf/pdfimportoptions.ui
+++ b/scribus/plugins/import/pdf/pdfimportoptions.ui
@@ -175,6 +175,41 @@
          </layout>
         </widget>
        </item>
+        <item>
+          <widget class="QGroupBox" name="groupBox_2">
+            <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+              </sizepolicy>
+            </property>
+            <property name="title">
+              <string/>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_8">
+              <item>
+                <widget class="QRadioButton" name="textAsVectors">
+                  <property name="enabled">
+                    <bool>true</bool>
+                  </property>
+                  <property name="text">
+                    <string>Import Text As Vectors</string>
+                  </property>
+                  <property name="checked">
+                    <bool>true</bool>
+                  </property>
+                </widget>
+              </item>
+              <item>
+                <widget class="QRadioButton" name="textAsText">
+                  <property name="text">
+                    <string>Import Text As Text</string>
+                  </property>
+                </widget>
+              </item>
+            </layout>
+          </widget>
+        </item>               
        <item>
         <spacer name="verticalSpacer">
          <property name="orientation">

--- a/scribus/plugins/import/pdf/slaoutput.cpp
+++ b/scribus/plugins/import/pdf/slaoutput.cpp
@@ -283,6 +283,7 @@ SlaOutputDev::SlaOutputDev(ScribusDoc* doc, QList<PageItem*> *Elements, QStringL
 	importerFlags = flags;
 	currentLayer = m_doc->activeLayer();
 	layersSetByOCG = false;
+	importTextAsVectors - true;
 }
 
 SlaOutputDev::~SlaOutputDev()
@@ -3314,7 +3315,7 @@ void SlaOutputDev::drawChar(GfxState* state, double x, double y, double dx, doub
 			FPointArray textPath;
 			textPath.fromQPainterPath(qPath);
 			FPoint wh = textPath.widthHeight();
-			if (m_import_text_as_vectors) {
+			if (importTextAsVectors) {
 				qDebug() << "drawChar() ";
 
 				if (textRenderingMode > 3)
@@ -3354,7 +3355,7 @@ void SlaOutputDev::drawChar(GfxState* state, double x, double y, double dx, doub
 				delete fontPath;
 			}
 		}
-		if (!m_import_text_as_vectors) { // donm't render the char as vectors add it to an array so it can be rendred as a string
+		if (!importTextAsVectors) { // donm't render the char as vectors add it to an array so it can be rendred as a string
 			addChar(state, x, y, dx, dy, originX, originY, code, nBytes, u, uLen);
 		}
 	}
@@ -3363,6 +3364,8 @@ void SlaOutputDev::drawChar(GfxState* state, double x, double y, double dx, doub
 GBool SlaOutputDev::beginType3Char(GfxState *state, double x, double y, double dx, double dy, CharCode code, POPPLER_CONST_082 Unicode *u, int uLen)
 {
 //	qDebug() << "beginType3Char";
+	if (importTextAsVectors == false)
+		return gTrue;
 	GfxFont *gfxFont;
 	if (!(gfxFont = state->getFont()))
 		return gTrue;
@@ -3378,6 +3381,8 @@ GBool SlaOutputDev::beginType3Char(GfxState *state, double x, double y, double d
 void SlaOutputDev::endType3Char(GfxState *state)
 {
 //	qDebug() << "endType3Char";
+	if (importTextAsVectors == false)
+		return;
 	F3Entry f3e = m_F3Stack.pop();
 	groupEntry gElements = m_groupStack.pop();
 	m_doc->m_Selection->clear();

--- a/scribus/plugins/import/pdf/slaoutput.h
+++ b/scribus/plugins/import/pdf/slaoutput.h
@@ -301,7 +301,7 @@ public:
 	void updateFillColor(GfxState *state) override;
 	void updateStrokeColor(GfxState *state) override;
 	void updateFontForVector(GfxState* state);
-	bool m_import_text_as_vectors = true;
+	bool importTextAsVectors;
 
 	//----- text drawing
 	void  beginTextObject(GfxState *state) override;


### PR DESCRIPTION
enable choosing if text should be imported as vectors or text
implement the flag in the appropriate functions to turn on or off vector or text support